### PR TITLE
Add column hide/show toggles to tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ Currently works with WVW and Detailed WVW logs. Partially working with PVElogs, 
  - Double click the `TopStats.exe` to run
  - Open the file `/Example_Output/Top_Stats_Index.html` in your browser of choice.
  - Drag and Drop the file `Drag_and_Drop_Log_Summary_for_2024yourdatatime.json` onto the opened `Top_Stats_Index.html` in your browser and click `import`
- - Open the 1. imported file link to view the summary
- - DM me with errors, suggestions and ideas. 
+- Open the 1. imported file link to view the summary
+- Use the collapsed **Columns** control above any table to hide or show individual columns
+- DM me with errors, suggestions and ideas.
  - Send example arcdps logs generating issues would be appreciated 
  
 **Optional**

--- a/Update_Files/$__JEL_TableSort.tid
+++ b/Update_Files/$__JEL_TableSort.tid
@@ -133,4 +133,42 @@ document.addEventListener('click', function (e) {
         // console.log(error)
     }
 });
+// Add column hide/show toggles for all tables
+document.addEventListener('DOMContentLoaded', function () {
+    document.querySelectorAll('table').forEach(function (table) {
+        var thead = table.querySelector('thead');
+        if (!thead) {
+            return;
+        }
+        var headers = Array.from(thead.querySelectorAll('th'));
+        if (!headers.length) {
+            return;
+        }
+        var details = document.createElement('details');
+        details.className = 'table-column-toggle';
+        var summary = document.createElement('summary');
+        summary.textContent = 'Columns';
+        details.appendChild(summary);
+        headers.forEach(function (th, index) {
+            var id = 'col-toggle-' + Math.random().toString(36).slice(2);
+            var label = document.createElement('label');
+            label.style.marginRight = '0.5em';
+            var checkbox = document.createElement('input');
+            checkbox.type = 'checkbox';
+            checkbox.id = id;
+            checkbox.checked = true;
+            checkbox.addEventListener('change', function () {
+                table.querySelectorAll('tr').forEach(function (row) {
+                    if (row.children[index]) {
+                        row.children[index].style.display = checkbox.checked ? '' : 'none';
+                    }
+                });
+            });
+            label.appendChild(checkbox);
+            label.appendChild(document.createTextNode(' ' + th.textContent.trim()));
+            details.appendChild(label);
+        });
+        table.parentNode.insertBefore(details, table);
+    });
+});
 </script>


### PR DESCRIPTION
## Summary
- add a collapsible **Columns** control above each table to toggle column visibility
- document how to use the column selector in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68c53a669c94832fbf96b687b35abfa7