### PR TITLE
Add dropdown column visibility controls

### DIFF
--- a/output_functions.py
+++ b/output_functions.py
@@ -605,55 +605,162 @@ def build_category_summary_table(top_stats: dict, category_stats: dict, enable_h
 				num_columns += 1
 		
 
-		style_info = "<style>\n/* === Column visibility rules === */\n"	
+		style_info = "<style>\n/* === Column visibility rules === */\n"
 		for i in range(4, num_columns):
 			if i == num_columns - 1:
 				style_info += f".col-toggle:has(#toggle-col{i+1}:not(:checked)) tr > *:nth-child({i+1}) {{\n  display: none;\n}}"
 			else:
 				style_info += f".col-toggle:has(#toggle-col{i+1}:not(:checked)) tr > *:nth-child({i+1}),\n"
-		hide_controls = "Hide Columns:"
-		for i, stat in enumerate(column_control_list):
-			hide_controls += f" <label><input type='checkbox' id='toggle-col{i+5}' checked> {stat}</label>"
-		hide_controls += "\n"
 		style_info += """
-.col-controls {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.3em 0.5em;
-  align-items: center;
-  background: #343a40;
-  color: #eee;
-  border-radius: 0.5em;
-  padding: 0.6em 1em;
+.col-toggle {
+  position: relative;
+  z-index: 10;
+}
+
+.col-dropdown {
+  position: relative;
+  display: inline-block;
   margin-bottom: 0.8em;
   font-size: 0.9em;
+  color: #eee;
+}
+
+.col-dropdown__summary {
+  list-style: none;
+  cursor: pointer;
+  background: #2c3034;
+  padding: 0.45em 0.9em;
+  border-radius: 0.5em;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
+  transition: background 0.2s ease;
+  user-select: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5em;
+}
+
+.col-dropdown__summary::-webkit-details-marker {
+  display: none;
+}
+
+.col-dropdown__summary::after {
+  content: "▾";
+  font-size: 0.8em;
+  opacity: 0.8;
+}
+
+.col-dropdown[open] .col-dropdown__summary {
+  background: #363c41;
+}
+
+.col-dropdown[open] .col-dropdown__summary::after {
+  content: "▴";
+}
+
+.col-dropdown__menu {
+  position: absolute;
+  top: calc(100% + 0.35em);
+  right: 0;
+  background: #1f2326;
+  border: 1px solid #444;
+  border-radius: 0.6em;
+  padding: 0.75em;
+  min-width: 18em;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6em;
+  box-shadow: 0 0.5em 1.5em rgba(0, 0, 0, 0.35);
+}
+
+.col-dropdown__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5em;
+}
+
+.col-dropdown__actions button {
+  background: #2c3034;
+  color: #eee;
+  border: 1px solid #555;
+  border-radius: 0.4em;
+  padding: 0.25em 0.8em;
+  cursor: pointer;
+  font-size: 0.85em;
+  transition: background 0.2s ease;
+}
+
+.col-dropdown__actions button:hover,
+.col-dropdown__actions button:focus-visible {
+  background: #3a3f44;
+}
+
+.col-controls {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(12em, 1fr));
+  gap: 0.4em 0.6em;
 }
 
 .col-controls label {
   display: flex;
   align-items: center;
-  gap: 0.2em;
-  background: #333;
-  padding: 0.2em 0.5em;
-  border-radius: 0.3em;
+  gap: 0.35em;
+  background: #2c3034;
+  padding: 0.35em 0.6em;
+  border-radius: 0.4em;
   cursor: pointer;
-  transition: background 0.2s;
+  transition: background 0.2s ease;
 }
 
 .col-controls label:hover {
-  background: #444;
+  background: #3a3f44;
 }
 
 .col-controls input[type="checkbox"] {
   accent-color: #6cf;
 }
 </style>
-<div class='col-toggle'>
-
-<div class="col-controls">"""
+<div class='col-toggle'>"""
+		hide_controls = """
+<details class="col-dropdown">
+  <summary class="col-dropdown__summary">Hide Columns</summary>
+  <div class="col-dropdown__menu">
+    <div class="col-dropdown__actions">
+      <button type="button" class="col-select-all">Select all</button>
+      <button type="button" class="col-clear-all">Clear all</button>
+    </div>
+    <div class="col-controls">"""
+		for i, stat in enumerate(column_control_list):
+			hide_controls += f"\n      <label><input type='checkbox' id='toggle-col{i+5}' checked> {stat}</label>"
+		hide_controls += "\n    </div>\n  </div>\n</details>\n</div>\n"
+		script_info = """
+<script>
+(function() {
+  if (window.__colDropdownInit) {
+    return;
+  }
+  window.__colDropdownInit = true;
+  document.addEventListener('click', function(event) {
+    const selectAllBtn = event.target.closest('.col-select-all');
+    const clearAllBtn = event.target.closest('.col-clear-all');
+    if (!selectAllBtn && !clearAllBtn) {
+      return;
+    }
+    event.preventDefault();
+    const dropdown = event.target.closest('.col-dropdown');
+    if (!dropdown) {
+      return;
+    }
+    const shouldCheck = Boolean(selectAllBtn);
+    dropdown.querySelectorAll('input[type="checkbox"]').forEach(function(box) {
+      box.checked = shouldCheck;
+      box.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+  });
+})();
+</script>"""
 		rows.append(style_info)
-		hide_controls += "\n</div>\n"
 		rows.append(hide_controls)
+		rows.append(script_info)
 	rows.append('<div style="overflow-y: auto; width: 100%; overflow-x:auto;">\n\n')
 	for toggle in ["Total", "Stat/1s", "Stat/60s"]:
 		rows.append(f'<$reveal stateTitle=<<currentTiddler>> stateField="category_radio" type="match" text="{toggle}" animate="yes">\n')


### PR DESCRIPTION
## Summary
- replace the inline "Hide Columns" checkbox list with a dropdown menu that keeps the controls out of the way
- add select-all and clear-all helpers plus updated styling to support the dropdown controls while retaining the existing CSS column toggles

## Testing
- python -m compileall output_functions.py

------
https://chatgpt.com/codex/tasks/task_e_68e217ba51e0832f8c0f81a1be7a4eba